### PR TITLE
[WIP]Issue-67「index.md のGitHub項目に以下2件インデックスを追加」項目のファイルアップロード #67

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,8 +12,8 @@
 1. [ブランチ名かぶり][14]
 1. [間違ってマージをした場合][54_7]
 1. [GitHubフロー(Issueの使用)][11]
-1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][]
-1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][]
+1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][72_1]
+1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][72_2]
 
 ## Swagger
 
@@ -38,5 +38,5 @@
 [54_7]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai7_revert.md "間違ってマージをした場合"
 [23]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerEditor.md "Swagger Editorの使用につい[て"
 [24]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "Swagger UIの使用について"
-[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md ChangeLogから、変更履歴と変更理由を明確化するためには？
-[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？
+[72_1]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "ChangeLogから、変更履歴と変更理由を明確化するためには？"
+[72_2]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？"

--- a/index.md
+++ b/index.md
@@ -12,7 +12,8 @@
 1. [ブランチ名かぶり][14]
 1. [間違ってマージをした場合][54_7]
 1. [GitHubフロー(Issueの使用)][11]
-
+1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][]
+1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][]
 
 ## Swagger
 
@@ -35,5 +36,7 @@
 [54_2]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai2_authority.md "リポジトリのユーザー権限について"
 [54_3]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai3_defy.md "GitHubメンバー参加拒否した場合"
 [54_7]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai7_revert.md "間違ってマージをした場合"
-[23]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerEditor.md "Swagger Editorの使用について"
+[23]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerEditor.md "Swagger Editorの使用につい[て"
 [24]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "Swagger UIの使用について"
+[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md ChangeLogから、変更履歴と変更理由を明確化するためには？
+[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？

--- a/index.md
+++ b/index.md
@@ -12,8 +12,8 @@
 1. [ブランチ名かぶり][14]
 1. [間違ってマージをした場合][54_7]
 1. [GitHubフロー(Issueの使用)][11]
-1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][72_1]
-1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][72_2]
+1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][]
+1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][]
 
 ## Swagger
 
@@ -38,5 +38,5 @@
 [54_7]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai7_revert.md "間違ってマージをした場合"
 [23]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerEditor.md "Swagger Editorの使用につい[て"
 [24]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "Swagger UIの使用について"
-[72_1]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "ChangeLogから、変更履歴と変更理由を明確化するためには？"
-[72_2]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？"
+[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md ChangeLogから、変更履歴と変更理由を明確化するためには？
+[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？

--- a/index.md
+++ b/index.md
@@ -12,8 +12,8 @@
 1. [ブランチ名かぶり][14]
 1. [間違ってマージをした場合][54_7]
 1. [GitHubフロー(Issueの使用)][11]
-1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][]
-1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][]
+1. [ChangeLogから、変更履歴と変更理由を明確化するためには？][72_1]
+1. [リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？][72_2]
 
 ## Swagger
 
@@ -38,5 +38,5 @@
 [54_7]: https://github.com/akekaneko/swagger-sample/blob/master/Github_kadai7_revert.md "間違ってマージをした場合"
 [23]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerEditor.md "Swagger Editorの使用につい[て"
 [24]: https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md "Swagger UIの使用について"
-[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md ChangeLogから、変更履歴と変更理由を明確化するためには？
-[]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？
+[72_1]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md ChangeLogから、変更履歴と変更理由を明確化するためには？
+[72_2]https://github.com/akekaneko/swagger-sample/blob/master/SwaggerUI.md リモート側で新規ブランチを作成した場合、ローカルに持ってくる方法はあるか？


### PR DESCRIPTION
## Issue番号
#67 5/8 新規課題についてindex更新とマークダウン新規作成

## 作業内容
「index.md のGitHub項目に以下2件インデックスを追加」項目のファイルアップロード する。
アップロードするファイル名は以下の通り。
index.md

## 備考
ファイルのリンクが不明のため記載してません。
